### PR TITLE
Fix animation speed/5 cat height/mid-collect berry bug

### DIFF
--- a/Assets/Objects/Can Animations/Can Animator.controller
+++ b/Assets/Objects/Can Animations/Can Animator.controller
@@ -17,10 +17,10 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 1
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0.0068478216
+  m_ExitTime: 28.929125
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -39,7 +39,7 @@ AnimatorStateMachine:
     m_Position: {x: 330, y: 200, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -3460053520792329130}
-    m_Position: {x: 459.3996, y: 354.73914, z: 0}
+    m_Position: {x: 620, y: 310, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 923920169720505692}
     m_Position: {x: 290, y: 470, z: 0}
@@ -87,7 +87,10 @@ AnimatorStateTransition:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  m_Conditions: []
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: AnimComplete
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 923920169720505692}
   m_Solo: 0
@@ -96,7 +99,29 @@ AnimatorStateTransition:
   serializedVersion: 3
   m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 1.0003837
+  m_ExitTime: 1
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 4
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-814971269722270156
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3489929841274741642}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
@@ -116,13 +141,19 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: Revive
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
+  - m_Name: AnimComplete
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -157,7 +188,33 @@ AnimatorState:
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: 0d528eb73d7c8eb45a9f89e5d3f004f4, type: 2}
+  m_Motion: {fileID: 7400000, guid: 3142c783622599941af208525e3bae75, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &2676261388319218283
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: New State
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 
@@ -190,6 +247,28 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &4342466293074670615
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 2676261388319218283}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.9375
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &8985388872481135542
 AnimatorStateTransition:
   m_ObjectHideFlags: 1

--- a/Assets/Objects/Can Animations/Collect.anim
+++ b/Assets/Objects/Can Animations/Collect.anim
@@ -526,10 +526,3 @@ AnimationClip:
     floatParameter: 0
     intParameter: 0
     messageOptions: 0
-  - time: 2
-    functionName: DestroyGameObject
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0

--- a/Assets/Objects/Can Animations/Dead.anim
+++ b/Assets/Objects/Can Animations/Dead.anim
@@ -1,0 +1,169 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Dead
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.016666668
+        value: {x: 0, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: 
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 3
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.016666668
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.016666668
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.x
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.016666668
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.y
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.016666668
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.z
+    path: 
+    classID: 4
+    script: {fileID: 0}
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Objects/Can Animations/Dead.anim.meta
+++ b/Assets/Objects/Can Animations/Dead.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3142c783622599941af208525e3bae75
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Objects/Cat Animations/Climb Controller/H5 Cat.controller
+++ b/Assets/Objects/Cat Animations/Climb Controller/H5 Cat.controller
@@ -144,7 +144,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: ClimbH3
-  m_Speed: 1
+  m_Speed: 1.5
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 7080940917523236802}
@@ -203,31 +203,31 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Climb2
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Climb3
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Climb4
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: ShakeHead
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -249,7 +249,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: ClimbH4
-  m_Speed: 1
+  m_Speed: 1.5
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 2313845346008901106}
@@ -277,7 +277,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: ClimbH1
-  m_Speed: 1
+  m_Speed: 1.5
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -8245585945944590785}
@@ -305,7 +305,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: ShakeHead
-  m_Speed: 1
+  m_Speed: 1.5
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 6637213886330308152}
@@ -476,7 +476,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: ClimbH2
-  m_Speed: 1
+  m_Speed: 1.5
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -3133081415416451146}

--- a/Assets/Scripts/PlayRecord.cs
+++ b/Assets/Scripts/PlayRecord.cs
@@ -121,11 +121,6 @@ public class PlayRecord : MonoBehaviour
             isPowerupCollected = !isPowerupCollectedChanged ? latestState.isPowerupCollected : ParseIsPowerupCollected();
             powerupQuantity = !powerupQuantityChanged ? latestState.powerupQuantity : ParsePowerupQuantity();
         }
-        string v = "";
-        for (int i = 0; i < isPowerupCollected.Count; i++) {
-            v += (isPowerupCollected[i] ? "true" : "false") + " ";
-        }
-        Debug.Log(v);
         moves.Push(new MoveState(catPosition, catDirection, catHeight, blockMetadata, isPowerupCollected, powerupQuantity));
     }
 

--- a/Assets/Scripts/PlayRecord.cs
+++ b/Assets/Scripts/PlayRecord.cs
@@ -121,6 +121,11 @@ public class PlayRecord : MonoBehaviour
             isPowerupCollected = !isPowerupCollectedChanged ? latestState.isPowerupCollected : ParseIsPowerupCollected();
             powerupQuantity = !powerupQuantityChanged ? latestState.powerupQuantity : ParsePowerupQuantity();
         }
+        string v = "";
+        for (int i = 0; i < isPowerupCollected.Count; i++) {
+            v += (isPowerupCollected[i] ? "true" : "false") + " ";
+        }
+        Debug.Log(v);
         moves.Push(new MoveState(catPosition, catDirection, catHeight, blockMetadata, isPowerupCollected, powerupQuantity));
     }
 
@@ -175,7 +180,7 @@ public class PlayRecord : MonoBehaviour
     {
         for (int i = 0; i < allPowerupsInGame.Count; i++)
         {
-            if (!moveState.isPowerupCollected[i] && !allPowerupsInGame[i].activeSelf)
+            if (!moveState.isPowerupCollected[i] && !allPowerupsInGame[i].GetComponent<PowerupController>().isActive())
             {
                 allPowerupsInGame[i].GetComponent<PowerupController>().ReviveObject();
             } 

--- a/Assets/Scripts/PlayRecord.cs
+++ b/Assets/Scripts/PlayRecord.cs
@@ -121,6 +121,7 @@ public class PlayRecord : MonoBehaviour
             isPowerupCollected = !isPowerupCollectedChanged ? latestState.isPowerupCollected : ParseIsPowerupCollected();
             powerupQuantity = !powerupQuantityChanged ? latestState.powerupQuantity : ParsePowerupQuantity();
         }
+
         moves.Push(new MoveState(catPosition, catDirection, catHeight, blockMetadata, isPowerupCollected, powerupQuantity));
     }
 

--- a/Assets/Scripts/PlayerMovement/CatMovement.cs
+++ b/Assets/Scripts/PlayerMovement/CatMovement.cs
@@ -36,7 +36,7 @@ public class CatMovement : MonoBehaviour
     [SerializeField] private float rotateSpeed = 0.04f;
     private Transform catModelGameObject;
 
-    [SerializeField] private float climbAnimationTime = 4f;
+    [SerializeField] private float climbAnimationTime = 2.12f;
     public void MoveCat(DataClass.Directions dirIndex)
     {
         if (areBlocksMoving || Time.timeScale == 0 || isCatClimbing) // you don't want the cat to be able to move as blocks are falling; opens a can of worms in logic

--- a/Assets/Scripts/Powerups/PowerupController.cs
+++ b/Assets/Scripts/Powerups/PowerupController.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 public class PowerupController : MonoBehaviour
 {
     [SerializeField] private DataClass.PowerUp powerupType;
-    // Start is called before the first frame update
+
     public DataClass.PowerUp GetPowerupType() {
         return powerupType;
     }
@@ -13,19 +13,26 @@ public class PowerupController : MonoBehaviour
     public void DestroyCollider() {
         transform.GetComponent<CapsuleCollider>().enabled = false;
     }
-    public void DestroyGameObject()
+
+    public void ForceAnimationComplete()
     {
-        gameObject.SetActive(false); // sike; the object is not actually destroyed bc it can be revived with an undo
+
+        transform.GetComponent<Animator>().SetTrigger("AnimComplete");
     }
     public void ReviveObject()
     {
-        gameObject.SetActive(true);
         transform.GetComponent<CapsuleCollider>().enabled = true;
+        Debug.Log("reviving can");
         transform.GetComponent<Animator>().SetTrigger("Revive");
+    }
+    public bool isActive()
+    {
+        return transform.GetComponent<CapsuleCollider>().enabled; // a deactivated collider is an uncollectible powerup
     }
     void Start() // ideally we should find a way for PlayRecord to get the powerups, and not PowerupController to send it to PlayRecord, but the order of start function execution prevents this :(
     {
         PlayRecord playRecord = FindObjectOfType<PlayRecord>();
         playRecord.AddPowerupToList(this.gameObject);
+        playRecord.UndoEvent += (moveState) => ForceAnimationComplete();
     }
 }

--- a/Assets/Scripts/Powerups/PowerupController.cs
+++ b/Assets/Scripts/Powerups/PowerupController.cs
@@ -22,7 +22,6 @@ public class PowerupController : MonoBehaviour
     public void ReviveObject()
     {
         transform.GetComponent<CapsuleCollider>().enabled = true;
-        Debug.Log("reviving can");
         transform.GetComponent<Animator>().SetTrigger("Revive");
     }
     public bool isActive()

--- a/Assets/Scripts/Powerups/PowerupController.cs
+++ b/Assets/Scripts/Powerups/PowerupController.cs
@@ -16,7 +16,6 @@ public class PowerupController : MonoBehaviour
 
     public void ForceAnimationComplete()
     {
-
         transform.GetComponent<Animator>().SetTrigger("AnimComplete");
     }
     public void ReviveObject()


### PR DESCRIPTION
- Switches animation speed to 2.12 seconds, which is just beyond the animation length as desired
- Makes the 5 height cat animation speed the same as all other cats to prevent the jumping issue
- Fixes issue where collecting a powerup then undoing during the powerup's animation doesn't respawn the powerup